### PR TITLE
Add an explicit pyproject.toml example to README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -125,7 +125,23 @@ In your ``pyproject.toml`` make the following changes:
 	[tool.hatch.metadata.hooks.requirements_txt]
 	files = ["requirements.txt"]
 
-Optionally, you can also define groups of `optional dependencies <https://hatch.pypa.io/latest/config/dependency/#features>`_
+The resulting ``pyproject.toml`` should look something like:
+
+.. code-block:: toml
+
+	[build-system]
+	requires = ["hatchling", "hatch-requirements-txt"]
+	build-backend = "hatchling.build"
+
+	[project]
+	name = "my-project"
+	version = "1.0.0"
+	dynamic = ["dependencies"]
+
+	[tool.hatch.metadata.hooks.requirements_txt]
+	files = ["requirements.txt"]
+
+You can also define groups of `optional dependencies <https://hatch.pypa.io/latest/config/dependency/#features>`_
 (also known as "features") by appending ``optional-dependencies`` to ``project.dynamic`` and adding a table like:
 
 .. code-block:: toml


### PR DESCRIPTION
We have instructions like

> append `dependencies` to `project.dynamic`

but TOML isn't JSON, and beginners are likely to not understand that `project.` means "under the `[project]` table".

For this reason, I believe the inclusion of an explicit example makes things much more beginner-friendly.

(I also fixed the awkward use of "optional" twice in the same sentence.)