### PR TITLE
Pin tox<4 to work around the CI failures

### DIFF
--- a/.github/workflows/flake8.yml
+++ b/.github/workflows/flake8.yml
@@ -43,7 +43,7 @@ jobs:
           python -VV
           python -m site
           python -m pip install --upgrade pip setuptools wheel
-          python -m pip install tox
+          python -m pip install "tox<4"
 
       - name: "Run Flake8"
         if: steps.changes.outputs.code == 'true'

--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -47,7 +47,7 @@ jobs:
           python -VV
           python -m site
           python -m pip install --upgrade pip setuptools wheel
-          python -m pip install --upgrade tox virtualenv!=20.16.0
+          python -m pip install --upgrade "tox<4" virtualenv!=20.16.0
 
       - name: "Run mypy"
         if: steps.changes.outputs.code == 'true'

--- a/.github/workflows/python_ci.yml
+++ b/.github/workflows/python_ci.yml
@@ -65,7 +65,7 @@ jobs:
           python -VV
           python -m site
           python -m pip install --upgrade pip setuptools wheel
-          python -m pip install --upgrade tox virtualenv!=20.16.0
+          python -m pip install --upgrade "tox<4" virtualenv!=20.16.0
 
       - name: "Run Tests for Python ${{ matrix.config.python-version }}"
         if: steps.setup-python.outcome == 'success'

--- a/.github/workflows/python_ci_linux.yml
+++ b/.github/workflows/python_ci_linux.yml
@@ -66,7 +66,7 @@ jobs:
           python -VV
           python -m site
           python -m pip install --upgrade pip setuptools wheel
-          python -m pip install --upgrade tox virtualenv!=20.16.0
+          python -m pip install --upgrade "tox<4" virtualenv!=20.16.0
           python -m pip install --upgrade coverage_pyver_pragma
 
       - name: "Run Tests for Python ${{ matrix.config.python-version }}"
@@ -148,7 +148,7 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/')
         run: |
           python -m pip install --upgrade pip setuptools wheel
-          python -m pip install --upgrade tox
+          python -m pip install --upgrade "tox<4"
 
       - name: Build distributions 📦
         if: startsWith(github.ref, 'refs/tags/')

--- a/.github/workflows/python_ci_macos.yml
+++ b/.github/workflows/python_ci_macos.yml
@@ -64,7 +64,7 @@ jobs:
           python -VV
           python -m site
           python -m pip install --upgrade pip setuptools wheel
-          python -m pip install --upgrade tox virtualenv!=20.16.0
+          python -m pip install --upgrade "tox<4" virtualenv!=20.16.0
 
       - name: "Run Tests for Python ${{ matrix.config.python-version }}"
         if: steps.setup-python.outcome == 'success'

--- a/tox.ini
+++ b/tox.ini
@@ -33,6 +33,7 @@ skip_missing_interpreters = True
 isolated_build = True
 requires =
     pip>=21,!=22.2
+    tox<4
     tox-envlist>=0.2.1
     virtualenv!=20.16.0
 


### PR DESCRIPTION
As suggested by @ofek in #22. (These commits also appear there.)