### PR TITLE
Ignore comments and arguments intended for pip.

### DIFF
--- a/hatch_requirements_txt/__init__.py
+++ b/hatch_requirements_txt/__init__.py
@@ -28,6 +28,7 @@ Hatchling plugin to read project dependencies from ``requirements.txt``.
 
 # stdlib
 import os
+import re
 import warnings
 from typing import Dict, Iterable, List, Optional, Tuple, Type
 
@@ -44,6 +45,10 @@ __copyright__: str = "2022 Dominic Davis-Foster"
 __license__: str = "MIT License"
 __version__: str = "0.3.0"
 __email__: str = "dominic@davis-foster.co.uk"
+
+# Regular expression for matching comments at the end of requirements
+# From pip (pip/_internal/req/req_file.py#L45)
+COMMENT_RE = re.compile(r"(^|\s+)#.*$")
 
 
 def parse_requirements(requirements: Iterable[str]) -> Tuple[List[Requirement], List[str]]:
@@ -62,6 +67,8 @@ def parse_requirements(requirements: Iterable[str]) -> Tuple[List[Requirement], 
 		if line.lstrip().startswith('#'):
 			comments.append(line)
 		elif line:
+			# Strip comments from end of line
+			line = COMMENT_RE.sub('', line)
 			req = Requirement(line)
 			req.name = canonicalize_name(req.name)
 			parsed_requirements.append(req)

--- a/hatch_requirements_txt/__init__.py
+++ b/hatch_requirements_txt/__init__.py
@@ -50,6 +50,8 @@ __email__: str = "dominic@davis-foster.co.uk"
 # From pip (pip/_internal/req/req_file.py#L45)
 COMMENT_RE = re.compile(r"(^|\s+)#.*$")
 
+PIP_COMMAND_RE = re.compile(r"\s+(-[A-Za-z]|--[A-Za-z]+)")
+
 
 def parse_requirements(requirements: Iterable[str]) -> Tuple[List[Requirement], List[str]]:
 	"""
@@ -66,9 +68,15 @@ def parse_requirements(requirements: Iterable[str]) -> Tuple[List[Requirement], 
 	for line in requirements:
 		if line.lstrip().startswith('#'):
 			comments.append(line)
+		elif line.lstrip().startswith('-'):
+			# Likely an argument to pip from a requirements.txt file intended for pip
+			# (e.g. from pip-compile)
+			pass
 		elif line:
 			# Strip comments from end of line
 			line = COMMENT_RE.sub('', line)
+			if '-' in line:
+				line = PIP_COMMAND_RE.split(line)[0]
 			req = Requirement(line)
 			req.name = canonicalize_name(req.name)
 			parsed_requirements.append(req)
@@ -97,7 +105,10 @@ def load_requirements_files(files: List[str]) -> Tuple[List[Requirement], List[s
 		if not os.path.isfile(filename):
 			raise FileNotFoundError(filename)
 		with open(filename, encoding="UTF-8") as fp:
-			parsed_requirements, comments = parse_requirements(fp.read().splitlines())
+			contents = fp.read()
+			# Unfold lines ending with \
+			contents = re.sub(r"\\\s*\n", ' ', contents)
+			parsed_requirements, comments = parse_requirements(contents.splitlines())
 		all_parsed_requirements.extend(parsed_requirements)
 		all_comments.extend(comments)
 	return all_parsed_requirements, all_comments

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -113,6 +113,7 @@ def test_build_pip_compile_style(tmp_pathplus: PathPlus, build_func: Callable):
 files = ["requirements.txt"]
 """
 	(tmp_pathplus / "requirements.txt").write_lines([
+			"--index http://localhost:3141",
 			"alembic==1.9.1 \\",
 			"    --hash=sha256:a9781ed0979a20341c2cbb56bd22bd8db4fc1913f955e705444bd3a97c59fa32 \\",
 			"    --hash=sha256:f9f76e41061f5ebe27d4fe92600df9dd612521a7683f904dab328ba02cffa5a2",

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -106,6 +106,27 @@ allow-direct-references = true
 
 
 @pytest.mark.parametrize("build_func", [build_wheel, build_sdist])
+def test_build_pip_compile_style(tmp_pathplus: PathPlus, build_func: Callable):
+
+	pyproject_toml = pyproject_toml_header + """
+[tool.hatch.metadata.hooks.requirements_txt]
+files = ["requirements.txt"]
+"""
+	(tmp_pathplus / "requirements.txt").write_lines([
+			"alembic==1.9.1 \\",
+			"    --hash=sha256:a9781ed0979a20341c2cbb56bd22bd8db4fc1913f955e705444bd3a97c59fa32 \\",
+			"    --hash=sha256:f9f76e41061f5ebe27d4fe92600df9dd612521a7683f904dab328ba02cffa5a2",
+			"hatch-requirements-txt",
+			])
+
+	info = get_pkginfo(tmp_pathplus, build_func, pyproject_toml)
+	assert info.requires_dist == [
+			"alembic==1.9.1",
+			"hatch-requirements-txt",
+			]
+
+
+@pytest.mark.parametrize("build_func", [build_wheel, build_sdist])
 def test_build_unspecified(tmp_pathplus: PathPlus, build_func: Callable):
 
 	pyproject_toml = pyproject_toml_header + """

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -79,6 +79,33 @@ filename = "requirements.txt"
 
 
 @pytest.mark.parametrize("build_func", [build_wheel, build_sdist])
+def test_build_comments(tmp_pathplus: PathPlus, build_func: Callable):
+
+	pyproject_toml = pyproject_toml_header + """
+[tool.hatch.metadata.hooks.requirements_txt]
+files = ["requirements.txt"]
+
+[tool.hatch.metadata]
+allow-direct-references = true
+"""
+	(tmp_pathplus / "requirements.txt").write_lines([
+			"Foo",
+			"bar",
+			"# fizz",
+			"baz>1  # this is a comment",
+			"pip@ https://github.com/pypa/pip/archive/1.3.1.zip#sha1=da9234ee9982d4bbb3c72346a6de940a148ea686"
+			])
+
+	info = get_pkginfo(tmp_pathplus, build_func, pyproject_toml)
+	assert info.requires_dist == [
+			"bar",
+			"baz>1",
+			"foo",
+			"pip@ https://github.com/pypa/pip/archive/1.3.1.zip#sha1=da9234ee9982d4bbb3c72346a6de940a148ea686"
+			]
+
+
+@pytest.mark.parametrize("build_func", [build_wheel, build_sdist])
 def test_build_unspecified(tmp_pathplus: PathPlus, build_func: Callable):
 
 	pyproject_toml = pyproject_toml_header + """


### PR DESCRIPTION
Fixes #28 

Also allows files from `pip-compile` to be read by `hatch-requirements-txt`, but without the arguments doing anything.

